### PR TITLE
Support appbound credential

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ make build
 - For Windows
   - (When your profile name is `Default`)
   - (For Powershell user) Please replace `%HOMEPATH%` to `$HOME`
+
+  - For Chrome versions before v127 (before application-bound credentials):
 ```bash
 # Cookie
 hack-chrome-data.exe -kind cookie -targetpath "%HOMEPATH%\AppData\Local\Google\Chrome\User Data\Default\Network\Cookies" -localstate "%HOMEPATH%\AppData\Local\Google\Chrome\User Data\Local State"
@@ -34,30 +36,23 @@ hack-chrome-data.exe -kind cookie -targetpath "%HOMEPATH%\AppData\Local\Google\C
 hack-chrome-data.exe -kind logindata -targetpath "%HOMEPATH%\AppData\Local\Google\Chrome\User Data\Default\Login Data" -localstate "%HOMEPATH%\AppData\Local\Google\Chrome\User Data\Local State"
 ```
 
+- For Chrome v127+ (with application-bound credentials):
+  - You need to extract the master key using [Chrome-App-Bound-Encryption-Decryption](https://github.com/xaitax/Chrome-App-Bound-Encryption-Decryption)
+  - Then use the extracted key with the `-sessionstorage` option:
+```bash
+# Cookie
+hack-chrome-data.exe -kind cookie -targetpath "%HOMEPATH%\AppData\Local\Google\Chrome\User Data\Default\Network\Cookies" -sessionstorage <your-extracted-master-key>
+
+# Password　(This program doesn't support Password extraction atm)
+```
+
 - For macOS (Normal)
   - (When your profile name is `Default`)
   - HackChromeData asks to access keychain
     - (`security find-generic-password -wa "Chrome"` is called internally)
-````bash
+```bash
 # Cookie
 $ ./hack-chrome-data -kind cookie -targetpath ~/Library/Application\ Support/Google/Chrome/Default/Cookies
 
 # Password
 $ ./hack-chrome-data -kind logindata -targetpath ~/Library/Application\ Support/Google/Chrome/Default/Login\ Data
-
-````
-
-- For macOS (Use Keychain Value)
-  - (When your profile name is `Default`)
-  1. Get `Chrome Sesssion Storage` value on Keychain
-      - `security find-generic-password -wa "Chrome"`
-      - or you can get the value through forensic tool like [chainbreaker](https://github.com/n0fate/chainbreaker).
-  2. Decrypt cookies and passwords 
-```
-# Cookie
-$ ./hack-chrome-data -kind cookie -targetpath ~/Library/Application\ Support/Google/Chrome/Default/Cookies -sessionstorage <session storage value>
-
-# Password
-$ ./hack-chrome-data -kind logindata -targetpath ~/Library/Application\ Support/Google/Chrome/Default/Login\ Data -sessionstorage <session storage value>
-```
-

--- a/main.go
+++ b/main.go
@@ -17,14 +17,10 @@ func main() {
 	targetpath := flag.String("targetpath", "", "File path of the kind (Cookies or Login Data)")
 	kind := flag.String("kind", "", "cookie or logindata")
 	localState := flag.String("localstate", "", "File path of Local State file (Windows only)")
-	sessionstorage := flag.String("sessionstorage", "", "(optional) Chrome Sesssion Storage on Keychain (Mac only)")
+	sessionstorage := flag.String("sessionstorage", "", "(optional) Chrome Sesssion Storage on Keychain")
 
 	flag.Parse()
 	if *targetpath == "" || *kind == "" {
-		flag.Usage()
-		os.Exit(1)
-	}
-	if runtime.GOOS == "windows" && *localState == "" {
 		flag.Usage()
 		os.Exit(1)
 	}
@@ -45,6 +41,9 @@ func main() {
 			log.Fatalf("Failed to get master key: %v", err)
 		}
 		decryptedKey = base64.StdEncoding.EncodeToString(b)
+	} else if runtime.GOOS == "windows" {
+		// Direct master key input for Windows
+		decryptedKey = *sessionstorage
 	}
 	fmt.Println("Master Key: " + decryptedKey)
 

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"os"
 	"runtime"
+	"encoding/hex"
 )
 
 func main() {
@@ -42,8 +43,14 @@ func main() {
 		}
 		decryptedKey = base64.StdEncoding.EncodeToString(b)
 	} else if runtime.GOOS == "windows" {
-		// Direct master key input for Windows
-		decryptedKey = *sessionstorage
+		// Direct master key input for Windows.
+		// If a hex string is provided, convert it to a base64 encoded string.
+		inputKey := *sessionstorage
+		if keyBytes, err := hex.DecodeString(inputKey); err == nil {
+			decryptedKey = base64.StdEncoding.EncodeToString(keyBytes)
+		} else {
+			decryptedKey = inputKey
+		}
 	}
 	fmt.Println("Master Key: " + decryptedKey)
 


### PR DESCRIPTION
### What
Chrome v127 introduced application-bound credentials.
This MR supports it. (Key extraction part depends on https://github.com/xaitax/Chrome-App-Bound-Encryption-Decryption)